### PR TITLE
Ajout HaltOStop

### DIFF
--- a/datasets.csv
+++ b/datasets.csv
@@ -3,3 +3,4 @@ https://www.data.gouv.fr/fr/datasets/lieux-de-covoiturage-organisation-commune-d
 https://www.data.gouv.fr/fr/datasets/lieux-de-covoiturage-organisation-commune-de-saint-nabord/,GES,88,200068377,88429,Commune de Saint-Narbord avec 1 lieu lors de l'ajout
 https://www.data.gouv.fr/fr/datasets/lieux-de-covoiturage-organisation-mairie-de-salles-dangles/,NAQ,16,200070514,16359,Commune de Salles d'Angles avec 1 lieu lors de l'ajout
 https://www.data.gouv.fr/fr/datasets/lieux-de-covoiturage-a-la-ville-dantibes/,PAC,06,240600585,06004,Commune d'Antibes avec 2 lieux lors de l'ajout
+https://www.data.gouv.fr/fr/datasets/lieux-de-covoiturage-organisation-halt-o-stop/,,,,,Plateforme HaltOStop, France entière, 25 lieux lors de l'ajout


### PR DESCRIPTION
Ajout de https://www.data.gouv.fr/fr/datasets/lieux-de-covoiturage-organisation-halt-o-stop/